### PR TITLE
Remove scheduled integration tests

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -137,12 +137,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  scheduled-test:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Run full test suite
-        run: |
-          docker compose -f docker-compose.test.yml up --abort-on-container-exit


### PR DESCRIPTION
## Summary
- Removed the scheduled integration test job that was failing nightly due to missing .env file
- Kept the daily security scans (Trivy, Bandit, Safety, pip-audit, Semgrep) which are valuable for detecting new vulnerabilities

## Test plan
- [ ] Verify workflow file is valid
- [ ] Confirm security scans still run on schedule
- [ ] Ensure regular CI/CD on push/PR still works